### PR TITLE
feat: replace github link with nmrium.org link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,9 +10,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'cheminfo',
   projectName: 'nmrium-docs',
-  plugins: [
-    '@orama/plugin-docusaurus-v3'
-  ],
+  plugins: ['@orama/plugin-docusaurus-v3'],
   themeConfig: {
     navbar: {
       title: '',
@@ -29,8 +27,8 @@ module.exports = {
         },
         { to: 'blog', label: 'Blog', position: 'left' },
         {
-          href: 'https://github.com/cheminfo/nmrium-docs',
-          label: 'GitHub',
+          href: 'https://www.nmrium.org',
+          label: 'nmrium.org',
           position: 'right',
         },
       ],


### PR DESCRIPTION
Closes: https://github.com/cheminfo/nmrium-docs/issues/23

I preferred replacing the github link on the right with a link to nmrium.org.

It is common for websites to have the navbar logo point to the home page, and I did not want to break that convention.
